### PR TITLE
Fix citation sanitization edge cases

### DIFF
--- a/app/agent/lc_prompts.py
+++ b/app/agent/lc_prompts.py
@@ -2,13 +2,14 @@ SYSTEM = (
     "You are Chivon Powers, answering professional questions in first person.\n"
     "Lead with the direct answer, then support it with the strongest concrete evidence.\n"
     "Use only facts supported by the supplied evidence. If the evidence is insufficient, say so plainly instead of guessing.\n"
-    "Keep the response to 2–4 sentences and usually 60–120 words; a single-fact answer may be shorter.\n"
+    "Keep the response to 2-4 sentences and usually 60-120 words; a single-fact answer may be shorter.\n"
     "Sound like a warm expert: curious, practical, evaluation-first, confident without overclaiming, and lightly conversational.\n"
     "Draw on the full academic, data, product, and AI arc. Mention Lime only when it genuinely helps answer the question.\n"
     "Do not frame every answer as a job pitch unless the user asks about role fit.\n"
     "Stay within professional scope. Never disclose or repeat family details, income, phone numbers, email addresses, or home addresses.\n"
     "Lime claims may use the supplied indexed resume or the canonical LinkedIn profile. Never infer a Lime motivation, reporting line, confidential detail, responsibility, project, outcome, or metric beyond that evidence.\n"
-    "Do not add inline footnote markers; the application renders its deterministic source list separately."
+    "Do not add inline footnote markers; the application renders its deterministic source list separately.\n"
+    "Never use em dashes or en dashes. Use commas, periods, semicolons, or ordinary hyphens instead."
 )
 
 REFUSAL = (

--- a/app/agent/lg_controller.py
+++ b/app/agent/lg_controller.py
@@ -58,15 +58,26 @@ _PII_OUTPUT_RE = re.compile(
     r"(?:\b\d{5}(?:-\d{4})?\b)",
     re.I,
 )
-_INLINE_CITATION_RE = re.compile(
-    r"(?<!\w)[ \t]*(?:\(\s*)?"
+_CITATION_MARKER_PATTERN = (
     r"(?:"
     r"\[(?:\^?(?:(?:E|Source)\s*)?\d+"
     r"(?:\s*[,;–-]\s*(?:(?:E|Source)\s*)?\d+)*)\]"
     r"(?:\([^)]+\))?"
     r"|【[^】\n]{0,80}】"
     r")"
-    r"(?:\s*\))?",
+)
+_CITATION_ATTRIBUTION_RE = re.compile(
+    r"(?:,\s*)?\b"
+    r"(?:according\s+to|per|based\s+on|as\s+(?:shown|noted|documented)\s+in)"
+    r"\s+(?:the\s+)?(?:source\s+)?"
+    + _CITATION_MARKER_PATTERN
+    + r"\s*,?\s*",
+    re.I,
+)
+_INLINE_CITATION_RE = re.compile(
+    r"(?<!\w)[ \t]*(?:\(\s*)?"
+    + _CITATION_MARKER_PATTERN
+    + r"(?:\s*\))?",
     re.I,
 )
 _PRIVATE_QUESTION_PATTERNS = (
@@ -260,10 +271,21 @@ def validate_answer(answer: str, source_count: int) -> dict[str, Any]:
 
 
 def hide_inline_citations(answer: str) -> str:
-    """Remove model-generated citation markers; sources render separately."""
-    cleaned = _INLINE_CITATION_RE.sub("", answer or "")
+    """Normalize visible answer text; sources render separately."""
+    cleaned = _CITATION_ATTRIBUTION_RE.sub(
+        lambda match: " " if match.group(0).startswith(",") else "",
+        answer or "",
+    )
+    cleaned = _INLINE_CITATION_RE.sub("", cleaned)
+    cleaned = cleaned.replace("—", ", ").replace("–", "-")
     cleaned = re.sub(r"[ \t]{2,}", " ", cleaned)
     cleaned = re.sub(r"[ \t]+([,.;:!?])", r"\1", cleaned)
+    cleaned = re.sub(r",\s*,", ",", cleaned)
+    cleaned = re.sub(
+        r"(^|[.!?]\s+)([a-z])",
+        lambda match: match.group(1) + match.group(2).upper(),
+        cleaned,
+    )
     return cleaned.strip()
 
 
@@ -384,7 +406,7 @@ class LGController:
                     for item in content
                     if isinstance(item, dict)
                 )
-            token = str(content or "")
+            token = str(content or "").replace("—", ", ").replace("–", "-")
             if not token:
                 continue
             if first_token_ms is None:

--- a/app/agent/lg_utils.py
+++ b/app/agent/lg_utils.py
@@ -244,7 +244,7 @@ def compose_from_observations(question: str, steps: List[Tuple[Any, Any]]) -> st
             (
                 "system",
                 "You are Chivon. Write a final interview answer:\n"
-                "- Follow the canonical 2–4 sentence, normally 60–120 word policy.\n"
+                "- Follow the canonical 2-4 sentence, normally 60-120 word policy.\n"
                 "- Do not include citations or footnote markers in the answer.",
             ),
             ("human", "Question: {q}\n\nObserved context:\n{ctx}\n\nLocal labels:\n{labels}\n\nURLs:\n{urls}"),

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -17,7 +17,6 @@ from pydantic import BaseModel
 
 from app.services.ingest_index import ensure_index, index_status
 from app.agent.lg_controller import LGController
-from app.services.settings import LINKEDIN_PROFILE_URL
 
 load_dotenv()
 
@@ -134,26 +133,6 @@ def home() -> str:
         line-height: 1.6;
         margin-bottom: 32px;
       }}
-      .current-badge {{
-        display: inline-flex;
-        align-items: center;
-        gap: 7px;
-        margin: 0 0 24px;
-        padding: 7px 12px;
-        border-radius: 999px;
-        background: #f2ebf8;
-        color: #4B0082;
-        font-size: 13px;
-        font-weight: 700;
-        text-decoration: none;
-      }}
-      .current-badge::before {{
-        content: "";
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background: #36c275;
-      }}
       .card {{
         background: white;
         border: 1px solid #e0e0e0;
@@ -239,7 +218,6 @@ def home() -> str:
         Ask about my work across AI, data science, product, and research.<br/>
         Answers are grounded in approved professional sources and shaped with an evaluation-first mindset.
       </p>
-      <a class="current-badge" href="{LINKEDIN_PROFILE_URL}" target="_blank" rel="noreferrer">Currently at Lime · Senior Data Scientist, Payments &amp; Fraud</a>
       <div class="card">
         <label for="q">Enter your interview question:</label>
         <input id="q" placeholder="How has your experience prepared you for a role in AI?" />
@@ -305,7 +283,7 @@ def home() -> str:
         es.addEventListener("final", (evt) => {{
           const payload = JSON.parse(evt.data);
           const trace = payload.trace || {{}};
-          answer.textContent = payload.answer || answer.textContent;
+          answer.textContent = payload.answer;
           const latency = trace.latency_ms ? `${{Math.round(trace.latency_ms)}} ms` : "n/a";
           const refreshed = (payload.source_freshness || {{}}).profile_verified_at ||
             (payload.source_freshness || {{}}).index_built_at;

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -52,7 +52,6 @@ if os.getenv("LANGSMITH_API_KEY"):
     os.environ.setdefault("LANGCHAIN_PROJECT", "interview-me-agent")
 
 from services.ingest_index import ensure_index  # noqa: E402 - env is hydrated first
-from services.settings import LINKEDIN_PROFILE_URL  # noqa: E402
 
 logging.basicConfig(level=os.getenv("APP_LOG_LEVEL", "INFO"))
 logger = logging.getLogger("interview_agent")
@@ -221,7 +220,6 @@ with st.sidebar:
     if headshot_b64:
         st.image(f"data:image/png;base64,{headshot_b64}", width=160, caption="Chivon Powers, PhD")
         st.markdown("[LinkedIn](https://www.linkedin.com/in/chivon-powers-phd-a6730610/) · [GitHub](https://github.com/Chipowers/)")
-        st.success("● Currently at Lime · Senior Data Scientist, Payments & Fraud")
     else:
         st.info("Headshot image not found in /static (see logs).")
 
@@ -273,7 +271,6 @@ st.markdown(
             Ask about my work across AI, data science, product, and research.<br>
             Answers are grounded in approved professional sources and shaped with an evaluation-first mindset.
         </p>
-        <p><a href="{LINKEDIN_PROFILE_URL}" target="_blank">● Currently at Lime · Senior Data Scientist, Payments &amp; Fraud</a></p>
     </div>
     """,
     unsafe_allow_html=True,

--- a/tests/test_controller_api.py
+++ b/tests/test_controller_api.py
@@ -49,6 +49,19 @@ class ControllerApiTests(unittest.TestCase):
             "Both were grounded in measured outcomes.",
         )
 
+    def test_citation_attribution_is_removed_without_malformed_prose(self):
+        self.assertEqual(
+            hide_inline_citations(
+                "According to [1], the system reduced latency. "
+                "The evidence, as shown in [E2], supports that result."
+            ),
+            "The system reduced latency. The evidence supports that result.",
+        )
+        self.assertEqual(
+            hide_inline_citations("Per 【3†resume】, she led the evaluation."),
+            "She led the evaluation.",
+        )
+
     def test_production_controller_uses_lightweight_web_search_service(self):
         from app.agent import lg_controller
 
@@ -299,8 +312,10 @@ class ControllerApiTests(unittest.TestCase):
         self.assertIn(status["status"], {"ok", "degraded", "not_ready"})
         self.assertIn("index", status)
         page = home()
-        self.assertIn("Currently at Lime", page)
+        self.assertNotIn("Currently at Lime", page)
         self.assertIn('id="sources"', page)
+        self.assertIn("answer.textContent = payload.answer;", page)
+        self.assertNotIn("payload.answer || answer.textContent", page)
 
     def test_eval_dataset_has_at_least_sixty_cases(self):
         with open("app/eval/qas.yaml", encoding="utf-8") as handle:


### PR DESCRIPTION
## What changed

- Assign the SSE final answer directly so an empty sanitized answer clears citation-only streamed text.
- Remove citation attribution scaffolding such as `According to [1],` and `as shown in [E2],` together with the marker.
- Preserve grammatical spacing and capitalization after attribution removal.
- Include the previously requested long-dash normalization and removal of the Lime role banner, which were pushed after PR #13 had already merged.

## Root cause

The browser used a truthy fallback for `payload.answer`, so an intentionally empty normalized answer could not replace streamed content. The citation sanitizer also removed markers without recognizing the surrounding attribution phrase.

## Validation

- `python -m pytest -q` - 32 passed
- `python -m ruff check app tests` - passed
- `python -m compileall -q app tests` - passed
- `git diff --check` - passed
